### PR TITLE
Accept options as first argument for Metalsmith CLI

### DIFF
--- a/__tests__/minifier.js
+++ b/__tests__/minifier.js
@@ -66,4 +66,25 @@ describe("metalsmith-html-minifier", function () {
 		expect(defaultOptions).toEqual(jasmine.any(Object));
 		expect(defaultOptions).not.toEqual({});
 	});
+
+	it("should call minify with options as first argument", function () {
+		var htmlMinifier = require(module);
+		var options = {
+			"foo": "bar"
+		};
+		var plugin = htmlMinifier(options);
+
+		plugin({
+			"foo.html": {
+				"contents": "a",
+			}
+		}, {
+			// This isn't important
+		}, function () {
+			// This isn't important
+		});
+
+		var minify = require("html-minifier").minify;
+		expect(minify).toBeCalledWith("a", options);
+	});
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,17 @@ var defaults = require("lodash.defaultsdeep");
 var minify = require("html-minifier").minify;
 var minimatch = require("minimatch");
 
-module.exports = function htmlMinifier(pattern = "*.html", options = {}) {
+module.exports = function htmlMinifier(pattern, opts = {}) {
+	/* allow the first argument to be options */
+	var options = opts;
+	var patternDefault = "*.html";
+	if (typeof arguments[0] === "object") {
+		options = arguments[0];
+		options.pattern = options.pattern || patternDefault;
+	} else {
+		options.pattern = pattern || patternDefault;
+	}
+
 	defaults(options, {
 		// See the README explainations of each of these options
 		"collapseBooleanAttributes": true,
@@ -17,7 +27,7 @@ module.exports = function htmlMinifier(pattern = "*.html", options = {}) {
 	return function plugin(files, metalsmith, done) {
 		try {
 			Object.keys(files)
-			.filter(minimatch.filter(pattern, {
+			.filter(minimatch.filter(options.pattern, {
 				"matchBase": true
 			}))
 			.forEach(function (file) {


### PR DESCRIPTION
It looks like in order to be compatible with the Metalsmith CLI when using a `.json` config file, you need to be able to accept the options map as the first argument for the plugin. This fixes that while maintaining backwards compatibility with your previous API. If you're not concerned about backwards compatibility, you could cut out all this stuff.