### PR TITLE
Add check for array of patterns as first plugin argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ Metalsmith(__dirname)
     .build();
 ```
 
+You can also pass an array of globs to match filenames:
+
+```js
+var Metalsmith   = require("metalsmith");
+var htmlMinifier = require("metalsmith-html-minifier");
+Metalsmith(__dirname)
+    .use(htmlMinifier(["*.html", "*.xhtml"]))
+    .build();
+```
+
 To pass options to the minifier (to enable or disable optimizations):
 
 ```js

--- a/__tests__/minifier.js
+++ b/__tests__/minifier.js
@@ -44,6 +44,37 @@ describe("metalsmith-html-minifier", function () {
 		expect(minify).toBeCalledWith("b", options);
 	});
 
+	it("should call minify with each HTML and XHTML files' contents (two extensions)", function () {
+		var htmlMinifier = require(module);
+		var options = {
+			"foo": "bar",
+			"baz": "qux",
+		};
+		var plugin = htmlMinifier(["*.html", "*.xhtml"], options);
+		var files = {
+			"foo.html": {
+				"contents": "a",
+			},
+			"bar.xhtml": {
+				"contents": "b",
+			},
+			"baz.scss": {
+				"contents": "c",
+			}
+		};
+
+		plugin(files, {
+			// This isn't important
+		}, function () {
+			// This isn't important
+		});
+
+		var minify = require("html-minifier").minify;
+		expect(minify.mock.calls.length).toBe(2);
+		expect(minify).toBeCalledWith("a", options);
+		expect(minify).toBeCalledWith("b", options);
+	});
+
 	it("should call minify with default options when no options given", function () {
 		var htmlMinifier = require(module);
 		var plugin = htmlMinifier();

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ module.exports = function htmlMinifier(pattern, opts = {}) {
 	/* allow the first argument to be options */
 	var options = opts;
 	var patternDefault = "*.html";
-	if (typeof arguments[0] === "object") {
+	if (typeof arguments[0] === "object" && !Array.isArray(arguments[0])) {
 		options = arguments[0];
 		options.pattern = options.pattern || patternDefault;
 	} else {


### PR DESCRIPTION
Refs #22

This PR updates the type check for the first argument to handle the case where an array is passed.

The following combinations now work:

1. No args
1. A string pattern
1. An array of patterns
1. A string pattern with additional options
1. An array of patterns with additional options