### PR TITLE
Match the base file name for extensions

### DIFF
--- a/__tests__/minifier.js
+++ b/__tests__/minifier.js
@@ -118,4 +118,35 @@ describe("metalsmith-html-minifier", function () {
 		var minify = require("html-minifier").minify;
 		expect(minify).toBeCalledWith("a", options);
 	});
+
+	it("should call minify with each HTML files' contents matching the base name", function () {
+		var htmlMinifier = require(module);
+		var options = {
+			"foo": "bar",
+			"baz": "qux",
+		};
+		var plugin = htmlMinifier(undefined, options);
+		var files = {
+			"some/dir/that/exists/foo.html": {
+				"contents": "a",
+			},
+			"some/dir/that has spaces/bar.html": {
+				"contents": "b",
+			},
+			"html/in/the/path.html/baz.scss": {
+				"contents": "c",
+			}
+		};
+
+		plugin(files, {
+			// This isn't important
+		}, function () {
+			// This isn't important
+		});
+
+		var minify = require("html-minifier").minify;
+		expect(minify.mock.calls.length).toBe(2);
+		expect(minify).toBeCalledWith("a", options);
+		expect(minify).toBeCalledWith("b", options);
+	});
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ module.exports = function htmlMinifier(pattern, opts = {}) {
 		try {
 			Object.keys(files)
 			.forEach(function (file) {
-				if (multimatch(file, options.pattern).length) {
+				if (multimatch(file, options.pattern, {matchBase: true}).length) {
 					var data = files[file];
 					var contents = data.contents.toString();
 					var minified = minify(contents, options);


### PR DESCRIPTION
Refs #27

This PR fixes file name matching to use `matchBase` (which was broken in #22).

From the minimatch docs<sup>[\[1\]][1]</sup>:

> ### `matchBase`
>
> If set, then patterns without slashes will be matched against the basename of the path if it contains slashes. For example, `a?b` would match the path `/xyz/123/acb`, but not `/xyz/acb/123`.

  [1]:https://github.com/isaacs/minimatch/tree/013d64dc242213bab1cf090d4a9e6bdf02f61160#matchbase