### PR TITLE
Show 2.x in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Installation
 The usual:
 
 ```
-$ npm install --save metalsmith-html-minifier
+$ npm install --save metalsmith-html-minifier@2
 ```
 
 How do I use this thing?

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "jest-cli": "^18.0.0",
     "jscs": "^3.0.0"
   },
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "A Metalsmith plugin to minify HTML files.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This PR updates the install instructions to show 2.x instead of implying latest (which unfortunately includes prerelease versions).