### PR TITLE
Add .github directory to npm ignore list

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 *.tgz
+.github
 .gitattributes
 .gitignore
 .jscsrc


### PR DESCRIPTION
This PR adds the `.github` directory to the `.npmignore` patterns list.